### PR TITLE
Add deployment for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Purpose of this simulation is to give an introduction to "Multi-Agent-Systems" (MAS) for undergrad Students making their first steps in MAS. They can tweak the model parameters and observe the changes of the simulation state in each time steps via a GUI. Also some simple "live statistics" will be provided.
 
-For easy access on **Windows** you can access the ".exe"-File [here](https://raw.githubusercontent.com/MichaelBrueggemann/sheepsmeadow/dev/deployments/windows/sheepsmeadow.exe)
+For easy access on **Windows** you can access the ".exe"-File [here](https://raw.githubusercontent.com/MichaelBrueggemann/sheepsmeadow/dev/deployments/windows/sheepsmeadow.zip)
 
 # How to start 'Sheepsmeadow'?
 
@@ -188,3 +188,6 @@ In this simulation on the other hand, all agent have a finite order, so an agent
 ## 03.10.2024
 - Today I provided images to use in this README and inside the application. I created those images using [pixelart](https://www.pixilart.com/draw). Here I really learned to appreciate AI art generation, as I created raster-based images which aren't fun to upscale. 
 Fortunately, pixelart had an option to automatically upscale those images. This really boosted the design process and made my life significantly easier. 
+
+## 15.10.2024
+- Now it's also possible to deploy a ".dmg"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Purpose of this simulation is to give an introduction to "Multi-Agent-Systems" (MAS) for undergrad Students making their first steps in MAS. They can tweak the model parameters and observe the changes of the simulation state in each time steps via a GUI. Also some simple "live statistics" will be provided.
 
-For easy access on **Windows** you can access the ".exe"-File [here](https://raw.githubusercontent.com/MichaelBrueggemann/sheepsmeadow/dev/deployments/windows/sheepsmeadow.zip)
+For easy access on **Windows** you can access the ".exe"-File [here](https://raw.githubusercontent.com/MichaelBrueggemann/sheepsmeadow/deploy-macOS/deployments/windows/sheepsmeadow.zip)
 
 # How to start 'Sheepsmeadow'?
 

--- a/makefile
+++ b/makefile
@@ -19,13 +19,13 @@ JAR_FILE = sheepsmeadow.jar
 # Compile Java classes
 compile-source:
 	mkdir -p $(BUILD_DIR)
-	'javac' -d $(BUILD_DIR) -sourcepath $(SRC_DIR) -cp "src:.:libs/*:images/*" src/Controller/ModelWithUI.java
+	javac -d $(BUILD_DIR) -sourcepath $(SRC_DIR) -cp "src:.:libs/*:images/*" src/Controller/ModelWithUI.java
 	cp ./$(SRC_DIR)/Controller/index.html ./$(BUILD_DIR)/Controller/
 	cp -r images ./$(BUILD_DIR)/
 
 # compile and run the application
 run: compile-source
-	'java' -cp "bin:libs/*" $(MAIN_CLASS)
+	java -cp "bin:libs/*" $(MAIN_CLASS)
 
 compile-tests:
 	find tests -name '*.java' -print0 | xargs -0 javac -cp "src:bin:libs/*" -d bin
@@ -50,17 +50,14 @@ clean:
 
 
 deploy-linux-deb: $(JAR_FILE)
-	# create .deb
 	mkdir -p ./$(DEPLOYMENT_DIR)/linux-deb/
 	jpackage --name Sheepsmeadow --input . --main-jar $(DEPLOYMENT_DIR)/jar/sheepsmeadow.jar --main-class Controller.ModelWithUI --type deb --dest $(DEPLOYMENT_DIR)/linux-deb/
 
 deploy-macOS: $(JAR_FILE)
-# create .deb
-mkdir -p ./$(DEPLOYMENT_DIR)/macOS/
-jpackage --name Sheepsmeadow --input . --main-jar $(DEPLOYMENT_DIR)/jar/sheepsmeadow.jar --main-class Controller.ModelWithUI --type dmg --dest $(DEPLOYMENT_DIR)/macOS/
+	mkdir -p ./$(DEPLOYMENT_DIR)/macOS/
+	jpackage --name Sheepsmeadow --input . --main-jar $(DEPLOYMENT_DIR)/jar/sheepsmeadow.jar --main-class Controller.ModelWithUI --type dmg --dest $(DEPLOYMENT_DIR)/macOS/
 
 install-linux-deb: deploy-linux-deb
-	# copy .deb to /tmp
 	mkdir -p /tmp/sheepsmeadow
 	cp $(DEPLOYMENT_DIR)/linux-deb/sheepsmeadow_1.0_amd64.deb /tmp/sheepsmeadow
 	sudo apt install /tmp/sheepsmeadow/sheepsmeadow_1.0_amd64.deb

--- a/makefile
+++ b/makefile
@@ -54,6 +54,11 @@ deploy-linux-deb: $(JAR_FILE)
 	mkdir -p ./$(DEPLOYMENT_DIR)/linux-deb/
 	jpackage --name Sheepsmeadow --input . --main-jar $(DEPLOYMENT_DIR)/jar/sheepsmeadow.jar --main-class Controller.ModelWithUI --type deb --dest $(DEPLOYMENT_DIR)/linux-deb/
 
+deploy-macOS: $(JAR_FILE)
+# create .deb
+mkdir -p ./$(DEPLOYMENT_DIR)/macOS/
+jpackage --name Sheepsmeadow --input . --main-jar $(DEPLOYMENT_DIR)/jar/sheepsmeadow.jar --main-class Controller.ModelWithUI --type dmg --dest $(DEPLOYMENT_DIR)/macOS/
+
 install-linux-deb: deploy-linux-deb
 	# copy .deb to /tmp
 	mkdir -p /tmp/sheepsmeadow


### PR DESCRIPTION
# Features
- extended the `makefile` to also create ".dmg" files for macOS
- fixed some issues in the makefile regarding the commands
- changed the download format of the executables to a `zip` file